### PR TITLE
Detach kernel driver before claiming interface

### DIFF
--- a/linak-desk-control.py
+++ b/linak-desk-control.py
@@ -172,7 +172,7 @@ class LinakController(object):
 		if not self._handle:
 			raise Exception('Could not connect to usb device')
 
-		if self._handle.kernelDriverActive(0):
+		if os.name == 'posix' and self._handle.kernelDriverActive(0):
 			print("Detaching kernel driver")
 			self._handle.detachKernelDriver(0)
 

--- a/linak-desk-control.py
+++ b/linak-desk-control.py
@@ -172,6 +172,13 @@ class LinakController(object):
 		if not self._handle:
 			raise Exception('Could not connect to usb device')
 
+		if self._handle.kernelDriverActive(0):
+			print("Detaching kernel driver")
+			try:
+				self._handle.detachKernelDriver(0)
+			except usb1.USBError as e:
+				print("Warning: Could not detach kernel driver: {:s}".format(str(e)))
+
 		self._handle.claimInterface(0)
 		self._initDevice()
 

--- a/linak-desk-control.py
+++ b/linak-desk-control.py
@@ -174,10 +174,7 @@ class LinakController(object):
 
 		if self._handle.kernelDriverActive(0):
 			print("Detaching kernel driver")
-			try:
-				self._handle.detachKernelDriver(0)
-			except usb1.USBError as e:
-				print("Warning: Could not detach kernel driver: {:s}".format(str(e)))
+			self._handle.detachKernelDriver(0)
 
 		self._handle.claimInterface(0)
 		self._initDevice()


### PR DESCRIPTION
# Introduction
This PR adds code that attempts to detach the kernel's `usbhid` driver from the USB interface before claiming the interface.

# Background
I found this necessary in Raspbian, where the OS's `usbhid` driver grabs the CBD6S cable's interface, and it doesn't seem to be possible to prevent this using `udev` or `modprobe.d`. Happily, this is solvable in code instead 😊.

# Solution
First, we check if there is a kernel driver attached to the interface we are about to claim. If there is, then we request that it be detached.

If the driver was not detached successfully, the resulting USBError is propagated upstream to the client.